### PR TITLE
refactor: unify edit submission and form closing logic in BookShow

### DIFF
--- a/books/src/components/BookEdit.tsx
+++ b/books/src/components/BookEdit.tsx
@@ -3,15 +3,15 @@ import type { Book } from "../types/Book";
 
 interface BookEditProps {
   book: Book;
-  onEdit: (id: number, title: string) => void;
+  onSubmit: (id: number, title: string) => void;
 }
 
-const BookEdit: React.FC<BookEditProps> = ({ book, onEdit }) => {
+const BookEdit: React.FC<BookEditProps> = ({ book, onSubmit }) => {
   const [title, setTitle] = useState(book.title);
 
   const handleOnSubmit = (e) => {
     e.preventDefault();
-    onEdit(book.id, title);
+    onSubmit(book.id, title);
   };
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/books/src/components/BookShow.tsx
+++ b/books/src/components/BookShow.tsx
@@ -18,9 +18,14 @@ const BookShow: React.FC<BookShowProps> = ({ book, onDelete, onEdit }) => {
     setShowEdit(!showEdit);
   };
 
+  const handleSubmit = (id: number, newTitle: string) => {
+    onEdit(id, newTitle); // update state in App
+    setShowEdit(false); // close the form
+  };
+
   let content = <h3>{book.title}</h3>;
   if (showEdit) {
-    content = <BookEdit book={book} onEdit={onEdit} />;
+    content = <BookEdit book={book} onSubmit={handleSubmit} />;
   }
 
   return (


### PR DESCRIPTION
- Replaced separate onEdit and onSubmit props with a single onSubmit handler
- BookShow now manages both updating title and toggling form state
- BookEdit simplified to accept one prop (onSubmit) for clean API
- Ensures form closes upon successful title update