### PR TITLE
Add createBook API integration with inline error handling

### DIFF
--- a/books/src/App.tsx
+++ b/books/src/App.tsx
@@ -29,9 +29,14 @@ function App() {
   }, []); // ← this ensures it runs only once when the component mounts
 
   const createBook = async (title: string) => {
-    const newBook = await createBookService(title);
+    const result = await createBookService(title);
 
-    setBooks((prev) => [...prev, newBook]);
+    if (result.err) {
+      setErrorMsg(result.err);
+      return;
+    }
+
+    setBooks((prev) => [...prev, result.data!]);
   };
 
   const deleteBookById = async (id: number) => {

--- a/books/src/services/bookService.ts
+++ b/books/src/services/bookService.ts
@@ -1,5 +1,9 @@
 import axios from "axios";
-import type { Book, FetchBooksResponse } from "../types/bookTypes";
+import type {
+  Book,
+  CreateBookResponse,
+  FetchBooksResponse,
+} from "../types/bookTypes";
 
 const BASE_URL = "http://localhost:3001/books";
 
@@ -25,9 +29,21 @@ export const fetchBooks = async (retry = 2): Promise<FetchBooksResponse> => {
   }
 };
 
-export const createBook = async (title: string): Promise<Book> => {
-  const response = await axios.post(BASE_URL, { title });
-  return response.data;
+export const createBook = async (
+  title: string
+): Promise<CreateBookResponse> => {
+  try {
+    const response = await axios.post(BASE_URL, { title });
+    return { data: response.data, err: null };
+  } catch (err) {
+    // Optional: log raw error somewhere like Sentry or console
+    console.error("Fetch books error:", err);
+    // Friendly message for the UI
+    return {
+      data: null,
+      err: "Failed to create book. Please check your internet connection or try again later.",
+    };
+  }
 };
 
 export const deleteBookById = async (id: number): Promise<void> => {

--- a/books/src/types/bookTypes.ts
+++ b/books/src/types/bookTypes.ts
@@ -14,3 +14,17 @@ export interface BooksFailureResponse {
 }
 
 export type FetchBooksResponse = BooksSuccessReponse | BooksFailureResponse;
+
+export interface CreateBookSuccessResponse {
+  data: Book;
+  err: null;
+}
+
+export interface CreateBookFailureResponse {
+  data: null;
+  err: string;
+}
+
+export type CreateBookResponse =
+  | CreateBookSuccessResponse
+  | CreateBookFailureResponse;


### PR DESCRIPTION
- Implemented createBook function using service layer abstraction
- Display user-friendly error message on failure (e.g., network error)
- Ensured type safety by handling possible null response from service