### PR TITLE
feat(button): extend ButtonProps to support native button attributes

### DIFF
--- a/routing-system/src/App.tsx
+++ b/routing-system/src/App.tsx
@@ -6,12 +6,12 @@ import { GoBell, GoDatabase, GoCloud } from "react-icons/go";
 function App() {
   return (
     <>
-      <div className="bg-blue-500 text-white text-xl p-4">
-        Tailwind is working?
-      </div>
-      <div className="bg-blue-500 text-white p-4">Tailwind Working?</div>
-
-      <Button buttonVariantProps={{ primary: true }} rounded outlined>
+      <Button
+        buttonVariantProps={{ primary: true }}
+        rounded
+        outlined
+        onClick={() => console.log("Clicked!")}
+      >
         <GoBell />
         Clicked Me!!
       </Button>

--- a/routing-system/src/components/Buttons/Button.tsx
+++ b/routing-system/src/components/Buttons/Button.tsx
@@ -3,18 +3,19 @@ import type { ButtonVariantProps } from "./button-types";
 import className from "classnames";
 import { twMerge } from "tailwind-merge";
 
-interface ButtonProps {
+type ButtonProps = {
   buttonVariantProps: ButtonVariantProps;
   outlined?: boolean;
   rounded?: boolean;
   children: React.ReactNode;
-}
+} & React.ButtonHTMLAttributes<HTMLButtonElement>; //  Inherit all button props
 
 const Button: React.FC<ButtonProps> = ({
   buttonVariantProps,
   outlined,
   rounded,
   children,
+  ...rest //  Collect all other props (like onClick)
 }) => {
   // Convert variant object to string
   const variant = Object.keys(
@@ -37,7 +38,11 @@ const Button: React.FC<ButtonProps> = ({
       "text-red-500": outlined && variant === "danger",
     })
   );
-  return <button className={classes}>{children}</button>;
+  return (
+    <button className={classes} {...rest}>
+      {children}
+    </button>
+  );
 };
 
 export default Button;


### PR DESCRIPTION
- Added intersection with React.ButtonHTMLAttributes<HTMLButtonElement>
- Button now supports onClick, disabled, type, and other native props
- Improves reusability and integration across the app