### PR TITLE
fix: handle stale state issue with functional state update in Accordion

### DIFF
--- a/routing-system/src/components/Accordion.tsx
+++ b/routing-system/src/components/Accordion.tsx
@@ -13,12 +13,12 @@ interface AccordionProps {
 const Accordion: React.FC<AccordionProps> = ({ items }) => {
   const [expandedIndex, setExpandedIndex] = useState(-1);
 
-  const handleClick = (index: number) => {
-    if (index === expandedIndex) {
-      setExpandedIndex(-1);
-    } else {
-      setExpandedIndex(index);
-    }
+  const handleClick = (nextIndex: number) => {
+    console.log("STALE expandedIndex:", expandedIndex); // outside setState
+    setExpandedIndex((current) => {
+      console.log("UP-TO-DATE expandedIndex:", current); // this is the correct one
+      return current === nextIndex ? -1 : nextIndex;
+    });
   };
 
   const renderedItems = items.map((item, index) => {


### PR DESCRIPTION
Used functional form of setExpandedIndex to ensure updates use the most recent state value. Added console logs to demonstrate stale vs. up-to-date state during rapid clicks.