### PR TITLE
feat(dropdown): close menu on option click

### DIFF
--- a/routing-system/src/components/DropDown.tsx
+++ b/routing-system/src/components/DropDown.tsx
@@ -12,8 +12,16 @@ export interface DropdownProps {
 const DropDown: React.FC<DropdownProps> = ({ options }) => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const handleOptionClcick = () => {
+    setIsOpen(false);
+  };
+
   const renderedOptions = options.map((option) => {
-    return <div key={option.value}>{option.label}</div>;
+    return (
+      <div key={option.value} onClick={handleOptionClcick}>
+        {option.label}
+      </div>
+    );
   });
 
   const content = isOpen && <div>{renderedOptions}</div>;


### PR DESCRIPTION
- Added `handleOptionClick` to close the dropdown when an option is selected
- Currently does not update selected item, just toggles visibility