### PR TITLE
Add logic to close dropdown and log selected option on option click

### DIFF
--- a/routing-system/src/components/DropDown.tsx
+++ b/routing-system/src/components/DropDown.tsx
@@ -12,13 +12,14 @@ export interface DropdownProps {
 const DropDown: React.FC<DropdownProps> = ({ options }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleOptionClcick = () => {
+  const handleOptionClcick = (option: DropDownOption) => {
     setIsOpen(false);
+    console.log(option.label);
   };
 
   const renderedOptions = options.map((option) => {
     return (
-      <div key={option.value} onClick={handleOptionClcick}>
+      <div key={option.value} onClick={() => handleOptionClcick(option)}>
         {option.label}
       </div>
     );


### PR DESCRIPTION
- Modified `handleOptionClick` to accept selected option as argument
- Closed the dropdown after user selection
- Logged selected option's label to console for debugging