### PR TITLE
feat(dropdown): implement dropdown component with type-safe props and selection handling

### DIFF
--- a/routing-system/src/components/DropDown.tsx
+++ b/routing-system/src/components/DropDown.tsx
@@ -1,20 +1,20 @@
 import React, { useState } from "react";
+import type { DropDownOption, DropdownProps } from "../types/DropDown.types";
 
-export interface DropDownOption {
-  label: string;
-  value: string;
-}
 
-export interface DropdownProps {
-  options: DropDownOption[];
-}
 
-const DropDown: React.FC<DropdownProps> = ({ options }) => {
+const DropDown: React.FC<DropdownProps> = ({
+  options,
+  selection,
+  onSelect,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOptionClcick = (option: DropDownOption) => {
     setIsOpen(false);
-    console.log(option.label);
+
+    //what option did the user clicked on
+    onSelect(option);
   };
 
   const renderedOptions = options.map((option) => {
@@ -31,9 +31,14 @@ const DropDown: React.FC<DropdownProps> = ({ options }) => {
     setIsOpen((currentIsOpen) => !currentIsOpen);
   };
 
+  let labelDetailsContent = "Select...";
+  if (selection) {
+    labelDetailsContent = selection.label;
+  }
+
   return (
     <div>
-      <div onClick={handleClick}>Select...</div>
+      <div onClick={handleClick}>{labelDetailsContent}</div>
       {content}
     </div>
   );

--- a/routing-system/src/pages/DropDownPage.tsx
+++ b/routing-system/src/pages/DropDownPage.tsx
@@ -1,10 +1,22 @@
+import { useState } from "react";
 import DropDown from "../components/DropDown";
 import { colorOptions } from "../data/dropdownOptions";
+import type { DropDownOption, SelectedOption } from "../types/DropDown.types";
 
 const DropDownPage = () => {
+  const [selection, setSelection] = useState<SelectedOption>(null);
+
+  const handleSelecttion = (option: DropDownOption) => {
+    setSelection(option);
+  };
+
   return (
     <>
-      <DropDown options={colorOptions} />
+      <DropDown
+        options={colorOptions}
+        selection={selection}
+        onSelect={handleSelecttion}
+      />
     </>
   );
 };

--- a/routing-system/src/types/DropDown.types.ts
+++ b/routing-system/src/types/DropDown.types.ts
@@ -1,0 +1,12 @@
+export interface DropDownOption {
+  label: string;
+  value: string;
+}
+
+export interface DropdownProps {
+  options: DropDownOption[];
+  selection: SelectedOption;
+  onSelect: (option: DropDownOption) => void;
+}
+
+export type SelectedOption = DropDownOption | null;


### PR DESCRIPTION
- Created DropDown.types.ts to define DropDownOption, SelectedOption, and DropdownProps interfaces
- Implemented DropDown.tsx component using internal isOpen state and external selection state via props
- Created DropDownPage.tsx to demonstrate usage with selection state and handleSelect callback