### PR TITLE
refactor: follow controlled component naming conventions in DropDownPage

### DIFF
--- a/routing-system/src/components/DropDown.tsx
+++ b/routing-system/src/components/DropDown.tsx
@@ -1,18 +1,14 @@
 import React, { useState } from "react";
 import type { DropDownOption, DropdownProps } from "../types/DropDown.types";
 
-const DropDown: React.FC<DropdownProps> = ({
-  options,
-  selection,
-  onSelect,
-}) => {
+const DropDown: React.FC<DropdownProps> = ({ options, value, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOptionClcick = (option: DropDownOption) => {
     setIsOpen(false);
 
     //what option did the user clicked on
-    onSelect(option);
+    onChange(option);
   };
 
   const renderedOptions = options.map((option) => {
@@ -31,7 +27,7 @@ const DropDown: React.FC<DropdownProps> = ({
 
   return (
     <div>
-      <div onClick={handleClick}>{selection?.label || "Select..."}</div>
+      <div onClick={handleClick}>{value?.label || "Select..."}</div>
       {content}
     </div>
   );

--- a/routing-system/src/pages/DropDownPage.tsx
+++ b/routing-system/src/pages/DropDownPage.tsx
@@ -4,18 +4,18 @@ import { colorOptions } from "../data/dropdownOptions";
 import type { DropDownOption, SelectedOption } from "../types/DropDown.types";
 
 const DropDownPage = () => {
-  const [selection, setSelection] = useState<SelectedOption>(null);
+  const [value, setValue] = useState<SelectedOption>(null);
 
-  const handleSelecttion = (option: DropDownOption) => {
-    setSelection(option);
+  const handleSelection = (option: DropDownOption) => {
+    setValue(option);
   };
 
   return (
     <>
       <DropDown
         options={colorOptions}
-        selection={selection}
-        onSelect={handleSelecttion}
+        value={value}
+        onChange={handleSelection}
       />
     </>
   );

--- a/routing-system/src/types/DropDown.types.ts
+++ b/routing-system/src/types/DropDown.types.ts
@@ -5,8 +5,8 @@ export interface DropDownOption {
 
 export interface DropdownProps {
   options: DropDownOption[];
-  selection: SelectedOption;
-  onSelect: (option: DropDownOption) => void;
+  value: SelectedOption;
+  onChange: (option: DropDownOption) => void;
 }
 
 export type SelectedOption = DropDownOption | null;


### PR DESCRIPTION
- Renamed props passed to DropDown: `selection` → `value`, `onSelect` → `onChange`
- Updated local state and handler to match the controlled component pattern
- Fixed typo in handler name: `handleSelecttion` → `handleSelection`
- Aligns with common form control conventions used in professional React projects