### PR TITLE
refactor: enhance DropDown with reusable Panel component 

### DIFF
--- a/routing-system/src/components/DropDown.tsx
+++ b/routing-system/src/components/DropDown.tsx
@@ -1,33 +1,45 @@
 import React, { useState } from "react";
 import type { DropDownOption, DropdownProps } from "../types/DropDown.types";
+import Panel from "./Panel";
+import { GoChevronDown } from "react-icons/go";
 
 const DropDown: React.FC<DropdownProps> = ({ options, value, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleOptionClcick = (option: DropDownOption) => {
+  const handleOptionClick = (option: DropDownOption) => {
     setIsOpen(false);
 
-    //what option did the user clicked on
-    onChange(option);
+    //You might want to prevent re-selecting the currently selected option:
+    if (option.value !== value?.value) {
+      onChange(option);
+    }
   };
 
   const renderedOptions = options.map((option) => {
     return (
-      <div key={option.value} onClick={() => handleOptionClcick(option)}>
+      <div key={option.value} onClick={() => handleOptionClick(option)}>
         {option.label}
       </div>
     );
   });
 
-  const content = isOpen && <div>{renderedOptions}</div>;
+  const content = isOpen && (
+    <Panel className="absolute top-full">{renderedOptions}</Panel>
+  );
 
   const handleClick = () => {
     setIsOpen((currentIsOpen) => !currentIsOpen);
   };
 
   return (
-    <div>
-      <div onClick={handleClick}>{value?.label || "Select..."}</div>
+    <div className="w-48 relative">
+      <Panel
+        onClick={handleClick}
+        className="flex justify-between items-center cursor-pointer"
+      >
+        {value?.label || "Select..."}
+        <GoChevronDown className="text-lg" />
+      </Panel>
       {content}
     </div>
   );

--- a/routing-system/src/components/Panel.tsx
+++ b/routing-system/src/components/Panel.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import classNames from "classnames";
+
+type PanelProps = {
+  children: React.ReactNode;
+  className: string;
+} & React.HTMLAttributes<HTMLDivElement>; //  Inherit all Div props
+
+const Panel: React.FC<PanelProps> = ({ children, className, ...rest }) => {
+  const findClassNames = classNames(
+    "border rounded p-3 shadow bg-white w-full",
+    className
+  );
+  return (
+    <div {...rest} className={findClassNames}>
+      {children}
+    </div>
+  );
+};
+
+export default Panel;


### PR DESCRIPTION
- Replaced inline dropdown wrapper with reusable <Panel /> component for consistent styling
- Used classnames library in Panel to allow merging of default and custom class names
- Enabled forwarding of extra props (e.g., event handlers) in Panel for flexibility