### PR TITLE
feat: add outside click detection using useRef and useEffect in DropDown

### DIFF
--- a/routing-system/src/components/DropDown.tsx
+++ b/routing-system/src/components/DropDown.tsx
@@ -1,10 +1,28 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { DropDownOption, DropdownProps } from "../types/DropDown.types";
 import Panel from "./Panel";
 import { GoChevronDown } from "react-icons/go";
 
 const DropDown: React.FC<DropdownProps> = ({ options, value, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
+
+  const divElRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      //console.log(divElRef.current);
+      if (
+        divElRef.current &&
+        !divElRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false); // click happened outside
+      }
+    };
+
+    document.addEventListener("click", handler, true);
+
+    return () => document.removeEventListener("click", handler, true); // Prevent memory leak or ghost clicks
+  }, []);
 
   const handleOptionClick = (option: DropDownOption) => {
     setIsOpen(false);
@@ -32,7 +50,7 @@ const DropDown: React.FC<DropdownProps> = ({ options, value, onChange }) => {
   };
 
   return (
-    <div className="w-48 relative">
+    <div ref={divElRef} className="w-48 relative">
       <Panel
         onClick={handleClick}
         className="flex justify-between items-center cursor-pointer"

--- a/routing-system/src/pages/DropDownPage.tsx
+++ b/routing-system/src/pages/DropDownPage.tsx
@@ -11,13 +11,13 @@ const DropDownPage = () => {
   };
 
   return (
-    <>
+    <div className="flex">
       <DropDown
         options={colorOptions}
         value={value}
         onChange={handleSelection}
       />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
- Introduced divElRef to reference the dropdown DOM element
- Added document-wide click listener using useEffect
- Implemented cleanup function to remove the event listener on unmount
- Ensured dropdown closes when clicking outside the component
- Added null check for divElRef.current to prevent runtime errors