### PR TITLE
fix: allow Cmd/Ctrl + click on custom links to open in new tab and style: apply blue text styling to custom link component

### DIFF
--- a/routing-system/src/my-react-router/MyLink.tsx
+++ b/routing-system/src/my-react-router/MyLink.tsx
@@ -12,6 +12,11 @@ const MyLink: React.FC<MyLinkProps> = ({ to, children }) => {
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
+    // Allow browser default behavior for new tab (Cmd/Ctrl + Click)
+    if (event.metaKey || event.ctrlKey) {
+      return;
+    }
+
     // Prevent full page reload
     event.preventDefault();
 

--- a/routing-system/src/my-react-router/MyLink.tsx
+++ b/routing-system/src/my-react-router/MyLink.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { NavigationContext } from "../context/NavigationContext";
+import classNames from "classnames";
 
 interface MyLinkProps {
   to: string;
@@ -8,6 +9,7 @@ interface MyLinkProps {
 
 const MyLink: React.FC<MyLinkProps> = ({ to, children }) => {
   const { navigate } = useContext(NavigationContext);
+  const classes = classNames("text-blue-500");
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -23,7 +25,7 @@ const MyLink: React.FC<MyLinkProps> = ({ to, children }) => {
     navigate(to);
   };
   return (
-    <a href={to} onClick={handleClick}>
+    <a className={classes} href={to} onClick={handleClick}>
       {children}
     </a>
   );


### PR DESCRIPTION
- Added support for metaKey (Mac) and ctrlKey (Windows)
- Prevent default navigation only for regular clicks
- Ensures custom links behave like standard anchor tags
- Used classNames utility to apply 'text-blue-500' Tailwind class
- Ensures links appear styled like traditional anchors
- No changes to logic or functionality