### PR TITLE
feat: highlight active link in Sidebar using activeClassName in MyLink

### DIFF
--- a/routing-system/src/components/SideBar.tsx
+++ b/routing-system/src/components/SideBar.tsx
@@ -10,7 +10,12 @@ const SideBar = () => {
 
   const renderedLinks = links.map((link) => {
     return (
-      <MyLink to={link.path} key={link.label} className="mb-12 bg-yellow-100">
+      <MyLink
+        to={link.path}
+        key={link.label}
+        className="mb-12 bg-yellow-100"
+        activeClassName="font-bold border-l-4 border-blue-500 pl-2"
+      >
         {link.label}
       </MyLink>
     );

--- a/routing-system/src/my-react-router/MyLink.tsx
+++ b/routing-system/src/my-react-router/MyLink.tsx
@@ -6,11 +6,21 @@ interface MyLinkProps {
   to: string;
   children: React.ReactNode;
   className?: string;
+  activeClassName?: string;
 }
 
-const MyLink: React.FC<MyLinkProps> = ({ to, children, className }) => {
-  const { navigate } = useNavigation();
-  const classes = classNames("text-blue-500", className);
+const MyLink: React.FC<MyLinkProps> = ({
+  to,
+  children,
+  className,
+  activeClassName,
+}) => {
+  const { navigate, currentPath } = useNavigation();
+  const classes = classNames(
+    "text-blue-500",
+    className,
+    currentPath === to && activeClassName
+  );
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>


### PR DESCRIPTION
- Added activeClassName prop support in MyLink
- Applied active styles (font-bold, border-l-4, border-blue-500, pl-2) when currentPath matches link
- Enabled visual cue to indicate the currently active page