### PR TITLE
fix: restrict sidebar link click area using items-start in flex layout

### DIFF
--- a/routing-system/src/components/SideBar.tsx
+++ b/routing-system/src/components/SideBar.tsx
@@ -22,7 +22,7 @@ const SideBar = () => {
   });
 
   return (
-    <div className="sticky top-0 overflow-y-scroll flex flex-col align-start">
+    <div className="sticky top-0 overflow-y-scroll flex flex-col item-start">
       {renderedLinks}
     </div>
   );

--- a/routing-system/src/components/SideBar.tsx
+++ b/routing-system/src/components/SideBar.tsx
@@ -22,7 +22,7 @@ const SideBar = () => {
   });
 
   return (
-    <div className="sticky top-0 overflow-y-scroll flex flex-col">
+    <div className="sticky top-0 overflow-y-scroll flex flex-col align-start">
       {renderedLinks}
     </div>
   );

--- a/routing-system/src/components/SideBar.tsx
+++ b/routing-system/src/components/SideBar.tsx
@@ -22,7 +22,7 @@ const SideBar = () => {
   });
 
   return (
-    <div className="sticky top-0 overflow-y-scroll flex flex-col item-start">
+    <div className="sticky top-0 overflow-y-scroll flex flex-col itemss-start">
       {renderedLinks}
     </div>
   );


### PR DESCRIPTION
- Applied 'items-start' to sidebar container to align links to the left
- Prevented extra clickable area to the right of link text
- Improves UX by limiting hover/click region to actual link content