### PR TITLE
fix: correct ExclusiveBooleanUnion type and remove unused React imports

### DIFF
--- a/routing-system/src/components/SideBar.tsx
+++ b/routing-system/src/components/SideBar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import MyLink from "../my-react-router/MyLink";
 
 const SideBar = () => {

--- a/routing-system/src/pages/ButtonPage.tsx
+++ b/routing-system/src/pages/ButtonPage.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { GoBell, GoDatabase, GoCloud } from "react-icons/go";
 import Button from "../components/Buttons/Button";
 

--- a/routing-system/src/types/exclusive-boolean-union.ts
+++ b/routing-system/src/types/exclusive-boolean-union.ts
@@ -1,4 +1,4 @@
 // exclusive-boolean-union.ts
 export type ExclusiveBooleanUnion<K extends string> = {
-  [Key in K]: { [P in Key]: true } & Partial<Record<Exclude<K, P>, false>>;
+  [Key in K]: { [P in Key]: true } & Partial<Record<Exclude<K, Key>, false>>;
 }[K];


### PR DESCRIPTION
- Fixed TypeScript error in `ExclusiveBooleanUnion` by declaring the mapped type key properly
- Removed unused `React` imports in files where JSX runtime auto-import handles it