### PR TITLE
feat: add single-button timer challenge with start/stop functionality

### DIFF
--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -12,13 +12,29 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
   const [isRunning, setIsRunning] = useState(false);
   const [timerExpired, setTimerExpired] = useState(false);
 
+  let timer: ReturnType<typeof setTimeout>;
+
   const handleStart = () => {
     if (isRunning || timerExpired) return; // prevent multiple starts
     setIsRunning(true);
-    setTimeout(() => {
+    timer = setTimeout(() => {
       setTimerExpired(true);
       setIsRunning(false);
     }, targetTime * 1000);
+
+  };
+
+  const handleStop = () => {
+    clearTimeout(timer);
+    setIsRunning(false);
+  };
+
+  const handleClick = () => {
+    if (isRunning) {
+      handleStop();
+    } else {
+      handleStart();
+    }
   };
 
   const timeText = `${targetTime} ${targetTime === 1 ? "second" : "seconds"}`;
@@ -35,8 +51,8 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       {timerExpired && <p>You lost</p>}
       <p className="challenge-time">{timeText}</p>
       <p>
-        <button onClick={handleStart} disabled={isRunning || timerExpired}>
-          {timerExpired ? "Stop " : "Start "}Challenge
+        <button onClick={handleClick} disabled={timerExpired}>
+          {isRunning ? "Stop " : "Start "}Challenge
         </button>
       </p>
       <p className={isRunning ? "active" : ""}>{statusText}</p>


### PR DESCRIPTION
- Implemented a single button to toggle between start and stop
- Displayed timer status and time remaining
- Disabled button after timer expires
- Used local `let timer` for setTimeout and clearTimeout
- Ensured ESLint-compliant function calls in handleClick