### PR TITLE
fix: move timer variable to module scope to persist across re-renders

### DIFF
--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -5,14 +5,14 @@ interface TimerChallengeProps {
   targetTime: number;
 }
 
+let timer: ReturnType<typeof setTimeout>;
+
 const TimerChallenge: React.FC<TimerChallengeProps> = ({
   title,
   targetTime,
 }) => {
   const [isRunning, setIsRunning] = useState(false);
   const [timerExpired, setTimerExpired] = useState(false);
-
-  let timer: ReturnType<typeof setTimeout>;
 
   const handleStart = () => {
     if (isRunning || timerExpired) return; // prevent multiple starts
@@ -21,7 +21,6 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       setTimerExpired(true);
       setIsRunning(false);
     }, targetTime * 1000);
-
   };
 
   const handleStop = () => {


### PR DESCRIPTION
- Previously, the `timer` variable was declared inside the component, causing it to reset on every render.
- As a result, `clearTimeout(timer)` in handleStop did not reference the correct timeout, and the timer callback executed even after stopping.
- Moved `timer` to the module level to persist the timeout ID across renders.
- Note: This approach assumes only a single instance of the component will be used, as the timer is now shared globally.