### PR TITLE
Fix: Move timer from global scope to useRef for component isolation

### DIFF
--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 
 interface TimerChallengeProps {
   title: string;
   targetTime: number;
 }
 
-let timer: ReturnType<typeof setTimeout>;
+//let timer: ReturnType<typeof setTimeout>;
 
 const TimerChallenge: React.FC<TimerChallengeProps> = ({
   title,
@@ -14,17 +14,24 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
   const [isRunning, setIsRunning] = useState(false);
   const [timerExpired, setTimerExpired] = useState(false);
 
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const handleStart = () => {
     if (isRunning || timerExpired) return; // prevent multiple starts
     setIsRunning(true);
-    timer = setTimeout(() => {
+    timer.current = setTimeout(() => {
+      console.log(`${title} timer expired`);
       setTimerExpired(true);
       setIsRunning(false);
     }, targetTime * 1000);
   };
 
   const handleStop = () => {
-    clearTimeout(timer);
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      // Reset the ref after clearing (cleaner logic)
+      timer.current = null;
+    }
     setIsRunning(false);
   };
 


### PR DESCRIPTION
- Previously, the `timer` variable was declared in the global scope, causing all TimerChallenge components to share the same timeout reference. This led to bugs where stopping a timer in one challenge would incorrectly affect (or fail to stop) another.

- Ensure proper cleanup with clearTimeout and null reset