### PR TITLE
feat: integrate ResultModal using native <dialog> and show modal on timer expiry

### DIFF
--- a/refs-portal-maximillian/src/components/ResultModal.tsx
+++ b/refs-portal-maximillian/src/components/ResultModal.tsx
@@ -1,13 +1,25 @@
 import type React from "react";
+import { useEffect } from "react";
 
 interface ResultModalProps {
   result: string;
   targetTime: number;
+  dialogRef: React.RefObject<HTMLDialogElement | null>;
 }
 
-const ResultModal: React.FC<ResultModalProps> = ({ result, targetTime }) => {
+const ResultModal: React.FC<ResultModalProps> = ({
+  result,
+  targetTime,
+  dialogRef,
+}) => {
+  // useEffect(() => {
+  //   if (dialogRef.current && !dialogRef.current.open) {
+  //     dialogRef.current.showModal(); // imperatively open the dialog
+  //   }
+  // }, [dialogRef]);
+
   return (
-    <dialog className="result-modal" open>
+    <dialog className="result-modal" ref={dialogRef}>
       <h2>{result}</h2>
       <p>
         The target time was <strong>{targetTime} seconds</strong>

--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -16,6 +16,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
   const [timerExpired, setTimerExpired] = useState(false);
 
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dialog = useRef<HTMLDialogElement | null>(null);
 
   const handleStart = () => {
     if (isRunning || timerExpired) return; // prevent multiple starts
@@ -24,6 +25,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       console.log(`${title} timer expired`);
       setTimerExpired(true);
       setIsRunning(false);
+      dialog.current?.showModal();
     }, targetTime * 1000);
   };
 
@@ -54,9 +56,11 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
 
   return (
     <>
-      {timerExpired && (
-        <ResultModal result="You Lost" targetTime={targetTime} />
-      )}
+      <ResultModal
+        result="You Lost"
+        targetTime={targetTime}
+        dialogRef={dialog}
+      />
       <section className="challenge">
         <h2>{title}</h2>
         <p className="challenge-time">{timeText}</p>


### PR DESCRIPTION
- Created ResultModal component using <dialog> element
- Passed ref from TimerChallenge to control modal behavior
- Triggered dialog.showModal() when timer expires
- Ensured clean separation of presentation (ResultModal) and logic (TimerChallenge)