### PR TITLE
Refactor ResultModal and TimerChallenge to use forwardRef with HTMLDialogElement

### DIFF
--- a/refs-portal-maximillian/src/components/ResultModal.tsx
+++ b/refs-portal-maximillian/src/components/ResultModal.tsx
@@ -1,37 +1,27 @@
-import type React from "react";
-import { useEffect } from "react";
+import { forwardRef } from "react";
 
 interface ResultModalProps {
   result: string;
   targetTime: number;
-  dialogRef: React.RefObject<HTMLDialogElement | null>;
 }
 
-const ResultModal: React.FC<ResultModalProps> = ({
-  result,
-  targetTime,
-  dialogRef,
-}) => {
-  // useEffect(() => {
-  //   if (dialogRef.current && !dialogRef.current.open) {
-  //     dialogRef.current.showModal(); // imperatively open the dialog
-  //   }
-  // }, [dialogRef]);
-
-  return (
-    <dialog className="result-modal" ref={dialogRef}>
-      <h2>{result}</h2>
-      <p>
-        The target time was <strong>{targetTime} seconds</strong>
-      </p>
-      <p>
-        You stopped the timer with <strong>X seconds left</strong>
-      </p>
-      <form method="dialog">
-        <button>Closed</button>
-      </form>
-    </dialog>
-  );
-};
+const ResultModal = forwardRef<HTMLDialogElement, ResultModalProps>(
+  function ResultModal({ result, targetTime }, dialogRef) {
+    return (
+      <dialog className="result-modal" ref={dialogRef}>
+        <h2>{result}</h2>
+        <p>
+          The target time was <strong>{targetTime} seconds</strong>
+        </p>
+        <p>
+          You stopped the timer with <strong>X seconds left</strong>
+        </p>
+        <form method="dialog">
+          <button>Closed</button>
+        </form>
+      </dialog>
+    );
+  }
+);
 
 export default ResultModal;

--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -56,11 +56,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
 
   return (
     <>
-      <ResultModal
-        result="You Lost"
-        targetTime={targetTime}
-        dialogRef={dialog}
-      />
+      <ResultModal result="You Lost" targetTime={targetTime} ref={dialog} />
       <section className="challenge">
         <h2>{title}</h2>
         <p className="challenge-time">{timeText}</p>


### PR DESCRIPTION
- Updated ResultModal to accept ref via forwardRef for <dialog> element
- Used useRef in TimerChallenge to control dialog visibility imperatively
- Replaced custom prop with ref in ResultModal usage