### PR TITLE
refactor: use useImperativeHandle with dialogRef for exposing open method in ResultModal

### DIFF
--- a/refs-portal-maximillian/src/components/ResultModal.tsx
+++ b/refs-portal-maximillian/src/components/ResultModal.tsx
@@ -1,12 +1,23 @@
-import { forwardRef } from "react";
+import { forwardRef, useImperativeHandle, useRef } from "react";
 
 interface ResultModalProps {
   result: string;
   targetTime: number;
 }
 
-const ResultModal = forwardRef<HTMLDialogElement, ResultModalProps>(
-  function ResultModal({ result, targetTime }, dialogRef) {
+export interface ResultModalHandle {
+  open: () => void;
+}
+
+const ResultModal = forwardRef<ResultModalHandle, ResultModalProps>(
+  function ResultModal({ result, targetTime }, ref) {
+    const dialogRef = useRef<HTMLDialogElement>(null);
+
+    useImperativeHandle(ref, () => ({
+      open: () => {
+        dialogRef.current?.showModal();
+      },
+    }));
     return (
       <dialog className="result-modal" ref={dialogRef}>
         <h2>{result}</h2>

--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import ResultModal from "./ResultModal";
+import ResultModal, { type ResultModalHandle } from "./ResultModal";
 
 interface TimerChallengeProps {
   title: string;
@@ -16,7 +16,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
   const [timerExpired, setTimerExpired] = useState(false);
 
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const dialog = useRef<HTMLDialogElement | null>(null);
+  const modalRef = useRef<ResultModalHandle>(null);
 
   const handleStart = () => {
     if (isRunning || timerExpired) return; // prevent multiple starts
@@ -25,7 +25,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       console.log(`${title} timer expired`);
       setTimerExpired(true);
       setIsRunning(false);
-      dialog.current?.showModal();
+      modalRef.current?.open();
     }, targetTime * 1000);
   };
 
@@ -56,7 +56,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
 
   return (
     <>
-      <ResultModal result="You Lost" targetTime={targetTime} ref={dialog} />
+      <ResultModal result="You Lost" targetTime={targetTime} ref={modalRef} />
       <section className="challenge">
         <h2>{title}</h2>
         <p className="challenge-time">{timeText}</p>


### PR DESCRIPTION
- Ensures the `open` method is typed correctly as returning void
- Avoids returning `void | undefined` by using block body in arrow function
- Keeps internal dialogRef for DOM access while exposing imperative methods via forwardRef