### PR TITLE
refactor: replace <dialog> with <div> in ResultModal and manage visibility via state

### DIFF
--- a/refs-portal-maximillian/src/components/ResultModal.tsx
+++ b/refs-portal-maximillian/src/components/ResultModal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef } from "react";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
 interface ResultModalProps {
   result: string;
@@ -11,26 +11,28 @@ export interface ResultModalHandle {
 
 const ResultModal = forwardRef<ResultModalHandle, ResultModalProps>(
   function ResultModal({ result, targetTime }, ref) {
-    const dialogRef = useRef<HTMLDialogElement>(null);
+    const [isVisible, setIsVisible] = useState(false);
 
     useImperativeHandle(ref, () => ({
       open: () => {
-        dialogRef.current?.showModal();
+        setIsVisible(true);
       },
     }));
     return (
-      <dialog className="result-modal" ref={dialogRef}>
-        <h2>{result}</h2>
-        <p>
-          The target time was <strong>{targetTime} seconds</strong>
-        </p>
-        <p>
-          You stopped the timer with <strong>X seconds left</strong>
-        </p>
-        <form method="dialog">
-          <button>Closed</button>
-        </form>
-      </dialog>
+      isVisible && (
+        <div className="result-modal">
+          <h2>{result}</h2>
+          <p>
+            The target time was <strong>{targetTime} seconds</strong>
+          </p>
+          <p>
+            You stopped the timer with <strong>X seconds left</strong>
+          </p>
+          <form method="dialog">
+            <button>Closed</button>
+          </form>
+        </div>
+      )
     );
   }
 );


### PR DESCRIPTION
-  Removed usage of native <dialog> element.
- Added internal state (`isVisible`) to toggle modal visibility.
- Updated `useImperativeHandle` to expose an `open()` method that sets visibility.
- Ensures compatibility across browsers and allows easier styling and customization.