### PR TITLE
feat: reset timer only after modal is closed by user

### DIFF
--- a/refs-portal-maximillian/src/components/ResultModal.tsx
+++ b/refs-portal-maximillian/src/components/ResultModal.tsx
@@ -4,6 +4,7 @@ interface ResultModalProps {
   result: string;
   targetTime: number;
   remainingTime: number;
+  onClose: () => void;
 }
 
 export interface ResultModalHandle {
@@ -11,7 +12,7 @@ export interface ResultModalHandle {
 }
 
 const ResultModal = forwardRef<ResultModalHandle, ResultModalProps>(
-  function ResultModal({ result, targetTime, remainingTime }, ref) {
+  function ResultModal({ result, targetTime, remainingTime, onClose }, ref) {
     const dialogRef = useRef<HTMLDialogElement>(null);
     const userLost = remainingTime <= 0;
     const formattedRemainingTime = (remainingTime / 1000).toFixed(2);
@@ -32,7 +33,7 @@ const ResultModal = forwardRef<ResultModalHandle, ResultModalProps>(
           You stopped the timer with
           <strong>{formattedRemainingTime} seconds left</strong>
         </p>
-        <form method="dialog">
+        <form method="dialog" onSubmit={onClose}>
           <button>Closed</button>
         </form>
       </dialog>

--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -30,7 +30,6 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
           clearInterval(timer.current!);
           // Reset the ref after clearing (cleaner logic)
           timer.current = null;
-          setTimeremaining(targetTime * 1000); //resetting to target time
           modalRef.current?.open(); // Show result when time is up
           return 0;
         }
@@ -47,6 +46,10 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       timer.current = null;
       modalRef.current?.open();
     }
+  };
+
+  const handleReset = () => {
+    setTimeremaining(targetTime * 1000); // Reset to full time
   };
 
   const handleClick = () => {
@@ -68,6 +71,7 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
         targetTime={targetTime}
         ref={modalRef}
         remainingTime={timerRemaining}
+        onClose={handleReset}
       />
       <section className="challenge">
         <h2>{title}</h2>


### PR DESCRIPTION
- Moved timer reset logic to parent function
- Passed reset function to ResultModal component as a prop
- Ensures timer is not immediately reset when time elapses
- Improves UX by preserving remaining time until user acknowledges result