### PR TITLE
perf(ui): improve performance and rendering logic in ResultModal and TimerChallenge

### DIFF
--- a/refs-portal-maximillian/src/components/ResultModal.tsx
+++ b/refs-portal-maximillian/src/components/ResultModal.tsx
@@ -1,26 +1,31 @@
-import { forwardRef, useImperativeHandle, useRef } from "react";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
 interface ResultModalProps {
   targetTime: number;
-  remainingTime: number;
   onClose: () => void;
 }
 
 export interface ResultModalHandle {
-  open: () => void;
+  open: (finalRemainingTime: number) => void;
 }
 
 const ResultModal = forwardRef<ResultModalHandle, ResultModalProps>(
-  function ResultModal({ targetTime, remainingTime, onClose }, ref) {
+  function ResultModal({ targetTime, onClose }, ref) {
     const dialogRef = useRef<HTMLDialogElement>(null);
-    const userLost = remainingTime <= 0;
-    const formattedRemainingTime = (remainingTime / 1000).toFixed(2);
-    const score = Math.round((1 - remainingTime / (targetTime * 1000)) * 100);
+    const [finalTime, setFinalTime] = useState<string | null>(null);
 
-    console.log(formattedRemainingTime);
+    const userLost = finalTime != null && +finalTime <= 0;
+
+    let score: number | undefined;
+    if (finalTime != null) {
+      score = Math.round((1 - +finalTime / targetTime) * 100);
+    }
 
     useImperativeHandle(ref, () => ({
-      open: () => {
+      open: (remainingTime) => {
+        const formattedRemainingTime = (remainingTime / 1000).toFixed(2);
+        setFinalTime(formattedRemainingTime);
+        console.log(formattedRemainingTime);
         dialogRef.current?.showModal();
       },
     }));
@@ -34,7 +39,7 @@ const ResultModal = forwardRef<ResultModalHandle, ResultModalProps>(
         </p>
         <p>
           You stopped the timer with
-          <strong>{formattedRemainingTime} seconds left</strong>
+          <strong>{finalTime} seconds left</strong>
         </p>
         <form method="dialog" onSubmit={onClose}>
           <button>Closed</button>

--- a/refs-portal-maximillian/src/components/TimerChallenge.tsx
+++ b/refs-portal-maximillian/src/components/TimerChallenge.tsx
@@ -30,7 +30,8 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
           clearInterval(timer.current!);
           // Reset the ref after clearing (cleaner logic)
           timer.current = null;
-          modalRef.current?.open(); // Show result when time is up
+          // When the timer stops automatically (timeRemaining <= 0) → you pass 0 as finalTime to ResultModal.open(0).
+          modalRef.current?.open(0); // Show result when time is up
           return 0;
         }
         return prevTimeRemaining - 10;
@@ -44,7 +45,8 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       clearInterval(timer.current);
       // Reset the ref after clearing (cleaner logic)
       timer.current = null;
-      modalRef.current?.open();
+      //When the timer stops manually (user clicks Stop) → you pass the actual remainingTime like ResultModal.open(remainingTime).
+      modalRef.current?.open(timerRemaining);
     }
   };
 
@@ -69,7 +71,6 @@ const TimerChallenge: React.FC<TimerChallengeProps> = ({
       <ResultModal
         targetTime={targetTime}
         ref={modalRef}
-        remainingTime={timerRemaining}
         onClose={handleReset}
       />
       <section className="challenge">


### PR DESCRIPTION
- Avoid unnecessary re-renders by conditionally setting state
- Improved score calculation and user feedback rendering
- Passed 0 to ResultModal when timer ends automatically
- Passed actual remaining time when stopped manually