### PR TITLE
feat: implement confirm modal for deleting visited places

### DIFF
--- a/prop-drilling-shop-maximillian/src/components/ConfirmModal.tsx
+++ b/prop-drilling-shop-maximillian/src/components/ConfirmModal.tsx
@@ -1,0 +1,35 @@
+import React, { forwardRef, useImperativeHandle, useRef } from "react";
+
+export interface ConfirmModalHandle {
+  open: () => void;
+  close: () => void;
+}
+
+export interface ConfirmModalProps {
+  onConfirm: () => void;
+}
+
+const ConfirmModal = forwardRef<ConfirmModalHandle, ConfirmModalProps>(
+  function ConfirmModal({ onConfirm }, ref) {
+    const dialogRef = useRef<HTMLDialogElement>(null);
+
+    useImperativeHandle(ref, () => ({
+      open: () => {
+        dialogRef.current?.showModal();
+      },
+      close: () => {
+        dialogRef.current?.close();
+      },
+    }));
+
+    return (
+      <dialog ref={dialogRef}>
+        <p>Are you sure you want to remove this place?</p>
+        <button onClick={onConfirm}>Yes</button>
+        <button onClick={() => dialogRef.current?.close()}>No</button>
+      </dialog>
+    );
+  }
+);
+
+export default ConfirmModal;

--- a/prop-drilling-shop-maximillian/src/components/VisitedPlaces.tsx
+++ b/prop-drilling-shop-maximillian/src/components/VisitedPlaces.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { AvailablePlace } from "../types/AvailablePlace";
+import type { ConfirmModalHandle } from "./ConfirmModal";
+import ConfirmModal from "./ConfirmModal";
 
 interface VisitedPlacesProps {
   place: AvailablePlace | null;
@@ -7,32 +9,60 @@ interface VisitedPlacesProps {
 
 const VisitedPlaces: React.FC<VisitedPlacesProps> = ({ place }) => {
   const [toVisit, setToVisit] = useState<AvailablePlace[]>([]);
-
-  const addPlaceToVisitPlaceList = useCallback(() => {
-    const alreadyVisitedPlace = toVisit.some(
-      (place1) => place?.id === place1.id
-    );
-
-    if (!alreadyVisitedPlace) {
-      setToVisit((previosVisitedPlace) => [place!, ...previosVisitedPlace]);
-    }
-  }, [place, toVisit]);
+  const modalRef = useRef<ConfirmModalHandle>(null);
+  const [placeToDelete, setPlaceToDelete] = useState<AvailablePlace | null>(
+    null
+  );
 
   useEffect(() => {
-    if (place) {
-      addPlaceToVisitPlaceList();
+    if (place && !toVisit.some((p) => p.id === place.id)) {
+      setToVisit((prev) => [place, ...prev]);
     }
-  }, [place, addPlaceToVisitPlaceList]);
+  }, [place]);
+
+  const handlePlaceClick = (place: AvailablePlace) => {
+    setPlaceToDelete(place);
+    modalRef.current?.open();
+  };
+
+  const handleConfirmDelete = () => {
+    if (!placeToDelete) return;
+
+    console.log("Trying to delete:", placeToDelete);
+
+    const updatedList = toVisit.filter(
+      (p) => p.id.toString() !== placeToDelete.id.toString()
+    );
+    console.log("Updated list:", updatedList);
+
+    setToVisit(updatedList);
+    setPlaceToDelete(null);
+    modalRef.current?.close();
+  };
 
   const renderedVisitedPlaces = toVisit.map((place1) => (
-    <li className={`place-item`} key={place1.id}>
+    <li
+      className={`place-item`}
+      key={place1.id}
+      onClick={() => handlePlaceClick(place1)}
+    >
       <button>
         <img src={place1.image.src} alt={place1.image.alt} />
         <h3>{place1.title}</h3>
       </button>
     </li>
   ));
-  return <ul className="places">{renderedVisitedPlaces}</ul>;
+
+  return (
+    <>
+      {toVisit.length === 0 ? (
+        <p>No places visited yet.</p>
+      ) : (
+        <ul className="places">{renderedVisitedPlaces}</ul>
+      )}
+      <ConfirmModal ref={modalRef} onConfirm={handleConfirmDelete} />
+    </>
+  );
 };
 
 export default VisitedPlaces;


### PR DESCRIPTION
- Added ConfirmModal component using forwardRef and useImperativeHandle to control dialog open/close externally.

- Integrated the modal into VisitedPlaces to confirm deletion of a selected place.

- Used useRef to manage modal visibility and useState to track the place pending deletion.

- Ensured modal opens on place click and removes place from the list upon confirmation.